### PR TITLE
Review initial nerfing attempt.

### DIFF
--- a/DarkHorizons/DarkHorizons.tp2
+++ b/DarkHorizons/DarkHorizons.tp2
@@ -13,7 +13,7 @@ ACTION_IF GAME_IS ~bgee~ THEN BEGIN
   PRINT @890 /* BG:EE install detected */
   INCLUDE ~%MOD_FOLDER%/lib/tbgcom_bgee_vars.tpa~
   INCLUDE ~%MOD_FOLDER%/lib/g3_bgee_cpmvars.tpa~
-		PRINT ~Game is bgee 
+		PRINT ~Game is bgee
 		~
 END ELSE
 ACTION_IF GAME_IS ~eet~ THEN BEGIN
@@ -21,7 +21,7 @@ ACTION_IF GAME_IS ~eet~ THEN BEGIN
   PRINT @895 /* EET install detected */
   INCLUDE ~%MOD_FOLDER%/lib/tbgcom_eet_vars.tpa~
   INCLUDE ~eet/other/cpmvars/eet_cpmvars.tpa~
-		PRINT ~Game is EET 
+		PRINT ~Game is EET
 		~
 END ELSE
 ACTION_IF GAME_IS ~tutu tutu_totsc~ THEN BEGIN
@@ -29,7 +29,7 @@ ACTION_IF GAME_IS ~tutu tutu_totsc~ THEN BEGIN
   PRINT @891 /* Tutu install detected. */
   INCLUDE ~%MOD_FOLDER%/lib/tbgcom_tutu_vars.tpa~
   INCLUDE ~%MOD_FOLDER%/lib/g3_tutu_cpmvars.tpa~
-		PRINT ~Game is tutu_totsc 
+		PRINT ~Game is tutu_totsc
 		~
 END ELSE
 ACTION_IF GAME_IS ~totsc~ THEN BEGIN
@@ -37,7 +37,7 @@ ACTION_IF GAME_IS ~totsc~ THEN BEGIN
   PRINT @894
   INCLUDE ~%MOD_FOLDER%/lib/tbgcom_bg_vars.tpa~
   INCLUDE ~%MOD_FOLDER%/lib/g3_bg_cpmvars.tpa~
-		PRINT ~Game is totsc 
+		PRINT ~Game is totsc
 		~
 END ELSE
 ACTION_IF GAME_IS ~bgt~ THEN BEGIN
@@ -45,7 +45,7 @@ ACTION_IF GAME_IS ~bgt~ THEN BEGIN
   PRINT @892 /* BGT install detected. */
   INCLUDE ~%MOD_FOLDER%/lib/tbgcom_bgt_vars.tpa~
   INCLUDE ~%MOD_FOLDER%/lib/g3_bgt_cpmvars.tpa~
-		PRINT ~Game is bgt 
+		PRINT ~Game is bgt
 		~
 END ELSE BEGIN
   /* Tell the player it is not Tutu or BGT */
@@ -163,7 +163,7 @@ END
 /* New and altered areas */
 //COPY ~DarkHorizons\areas~ ~override~
 COPY ~DarkHorizons\areas\CM0750.are~ ~override~
-  
+
 COPY ~DarkHorizons\areas\CM0750.BCS~ ~override~
 COPY ~DarkHorizons\areas\CM0750.mos~ ~override~
 COPY ~DarkHorizons\areas\CM0750.tis~ ~override~
@@ -5771,7 +5771,12 @@ COPY ~DarkHorizons/cre/MATHOREN.cre~ ~override/MATHOREN.cre~
 	REPLACE_CRE_ITEM ~PLAT05~ #0 #0 #0 ~unstealable&undroppable~ ~ARMOR~
 	REPLACE_CRE_ITEM ~AX1H03~ #0 #0 #0 ~unstealable&undroppable~ ~WEAPON2~
 	REPLACE_CRE_ITEM ~HELM04~ #0 #0 #0 ~unstealable&undroppable~ ~HELMET~
-	REPLACE_CRE_ITEM ~SHLD19~ #0 #0 #0 ~unstealable&undroppable~ ~SHIELD~
+  PATCH_IF (GAME_IS ~eet~) BEGIN
+	  REPLACE_CRE_ITEM ~SHLD19A~ #0 #0 #0 ~unstealable&undroppable~ ~SHIELD~
+  END
+  ELSE BEGIN
+    REPLACE_CRE_ITEM ~SHLD19~ #0 #0 #0 ~unstealable&undroppable~ ~SHIELD~
+  END
 
 COPY ~DarkHorizons/cre/CM01A514.CRE~ ~override/CM01A514.CRE~
   SAY NAME1 @654
@@ -5947,7 +5952,6 @@ COPY ~DarkHorizons/cre/CMGHST01.CRE~ ~override~
 COPY ~DarkHorizons/cre/CMGHST02.CRE~ ~override~
   SAY NAME1 @686
   SAY NAME2 @686
-	REPLACE_CRE_ITEM ~PLAT04~ #0 #0 #0 ~unstealable&undroppable~ ~ARMOR~
 	REPLACE_CRE_ITEM ~HELM06~ #0 #0 #0 ~unstealable&undroppable~ ~HELMET~
 
 COPY ~DarkHorizons/cre/CMGHST03.CRE~ ~override~
@@ -5957,12 +5961,12 @@ COPY ~DarkHorizons/cre/CMGHST03.CRE~ ~override~
 COPY ~DarkHorizons/cre/CMGHST04.CRE~ ~override~
   SAY NAME1 @686
   SAY NAME2 @686
-	REPLACE_CRE_ITEM ~PLAT04~ #0 #0 #0 ~unstealable&undroppable~ ~ARMOR~
 	REPLACE_CRE_ITEM ~HELM06~ #0 #0 #0 ~unstealable&undroppable~ ~HELMET~
 
 COPY ~DarkHorizons/cre/CMGHST05.CRE~ ~override~
   SAY NAME1 @687
   SAY NAME2 @687
+  REPLACE_CRE_ITEM ~DAGG15~ #0 #0 #0 ~none~ ~WEAPON1~
 
 COPY ~DarkHorizons/cre/CMGHST06.CRE~ ~override~
   SAY NAME1 @688
@@ -6080,7 +6084,7 @@ COPY ~DarkHorizons/cre/CMOSEC03.CRE~ ~override~
 
 COPY ~DarkHorizons/cre/CMOSEC04.CRE~ ~override~
   SAY NAME1 @716
-  SAY NAME2 @716 
+  SAY NAME2 @716
   WRITE_ASCII SCRIPT_OVERRIDE ~cmovers2~ (8)
   REPLACE_CRE_ITEM ~BRAC07~ #0 #0 #0 ~unstealable&undroppable~ ~GLOVES~
 
@@ -6245,13 +6249,11 @@ COPY ~DarkHorizons/cre/CMSEC13.CRE~ ~override~
 COPY ~DarkHorizons/cre/CMSEC14.CRE~ ~override~
   SAY NAME1 @738
   SAY NAME2 @738
-  REPLACE_CRE_ITEM ~PLAT04~ #0 #0 #0 ~unstealable&undroppable~ ~ARMOR~
   REPLACE_CRE_ITEM ~POTN14~ #0 #0 #0 ~unstealable&undroppable~ ~qitem3~
 
 COPY ~DarkHorizons/cre/CMSEC14A.CRE~ ~override~
   SAY NAME1 @738
   SAY NAME2 @738
-  REPLACE_CRE_ITEM ~PLAT04~ #0 #0 #0 ~unstealable&undroppable~ ~ARMOR~
   REPLACE_CRE_ITEM ~POTN14~ #0 #0 #0 ~unstealable&undroppable~ ~qitem3~
 
 COPY ~DarkHorizons/cre/CMSEC14B.CRE~ ~override~
@@ -6283,7 +6285,6 @@ COPY ~DarkHorizons/cre/CMSEC18.CRE~ ~override~
 COPY ~DarkHorizons/cre/CMSEC19.CRE~ ~override~
   SAY NAME1 @738
   SAY NAME2 @738
-  REPLACE_CRE_ITEM ~PLAT04~ #0 #0 #0 ~unstealable&undroppable~ ~ARMOR~
   REPLACE_CRE_ITEM ~SW2H02~ #0 #0 #0 ~unstealable&undroppable~ ~WEAPON2~
   REPLACE_CRE_ITEM ~BOW04~ #0 #0 #0 ~unstealable&undroppable~ ~WEAPON1~
   REPLACE_CRE_ITEM ~POTN14~ #0 #0 #0 ~unstealable&undroppable~ ~qitem3~
@@ -6314,7 +6315,6 @@ COPY ~DarkHorizons/cre/CMSEC23.CRE~ ~override~
 COPY ~DarkHorizons/cre/CMSEC24.CRE~ ~override~
   SAY NAME1 @738
   SAY NAME2 @738
-  REPLACE_CRE_ITEM ~PLAT04~ #0 #0 #0 ~unstealable&undroppable~ ~ARMOR~
   REPLACE_CRE_ITEM ~SW1H05~ #0 #0 #0 ~unstealable&undroppable~ ~WEAPON2~
   REPLACE_CRE_ITEM ~BOW02~ #0 #0 #0 ~unstealable&undroppable~ ~WEAPON1~
   REPLACE_CRE_ITEM ~POTN14~ #0 #0 #0 ~unstealable&undroppable~ ~qitem3~
@@ -6322,7 +6322,6 @@ COPY ~DarkHorizons/cre/CMSEC24.CRE~ ~override~
 COPY ~DarkHorizons/cre/CMSEC25.CRE~ ~override~
   SAY NAME1 @738
   SAY NAME2 @738
-  REPLACE_CRE_ITEM ~PLAT04~ #0 #0 #0 ~unstealable&undroppable~ ~ARMOR~
   REPLACE_CRE_ITEM ~SW1H05~ #0 #0 #0 ~unstealable&undroppable~ ~WEAPON2~
   REPLACE_CRE_ITEM ~BOW02~ #0 #0 #0 ~unstealable&undroppable~ ~WEAPON1~
   REPLACE_CRE_ITEM ~POTN14~ #0 #0 #0 ~unstealable&undroppable~ ~qitem3~
@@ -6387,7 +6386,6 @@ COPY ~DarkHorizons/cre/CMBOU08.CRE~ ~override~
 COPY ~DarkHorizons/cre/CMBOU09.CRE~ ~override~
   SAY NAME1 @792
   SAY NAME2 @792
-	REPLACE_CRE_ITEM ~DAGG15~ #0 #0 #0 ~none~ ~WEAPON2~
 
 COPY ~DarkHorizons/cre/CMBOU10.CRE~ ~override~
   SAY NAME1 @793
@@ -6799,7 +6797,7 @@ COPY ~DarkHorizons/cre/CMTMORW.cre~ ~override~
   WRITE_LONG SPELL_DISRUPTED   (0 - 1)
   WRITE_LONG SET_A_TRAP    (0 - 1)
   SAY BIO @974 /* When asked about her past, MORWEN says she came from a well to do family from the city of Neverwinter. She got her first taste of the epic poems and stories from the northern Skald bards when her family visited the Icewind Dale region when she was young. Ever since then she has been obsessed with their epic tales and adventures. She wished to learn from the Skald bards but they rarely ever came to Neverwinter, until the day that Dale the Bard made a stop there. She first saw him at one of the local pubs, singing his epic exploits in a song. She introduced herself to Dale and soon after he mentored Morwen in the Skald Bard skills as well as being an excellent archer. After learning these skills, she quickly grew bored of the uneventful Neverwinter high life and decided to travel south to the Sword Coast region after she heard about the iron crisis. She traveled to Beregost to find someone who is seeking adventure like herself. */
-	WRITE_BYTE  0x238 12                            // Strength 
+	WRITE_BYTE  0x238 12                            // Strength
 	WRITE_BYTE  0x23a 16                             // Intell
 	WRITE_BYTE  0x2b 12                             // Wisdom
 	WRITE_BYTE  0x23c 18                             // Dexterity


### PR DESCRIPTION
- Revert the prevention of dropping fullplates. Fullplates might be rare but they are considered as generic items.
- Move the Shocker from the Ghost Knight mage to the named T/M. (It makes more sense at the latter.)
- Fix Thorengrim using the BG2 variant of Pellan's Shield on EET.

I'm actually conflicted on the whole Ghost Knights vs Helm of Charm Protection deal. All the Firewine GKs have such, and theirs are pickpocketable/lootable. (They also technically have it for the immunity.)

There's also the fact that all these undroppable items introduced don't have a droppable-but-unstealable generic counterpart atm (something which could explain the avatar outfit for immersion). Probably adding the "substitutions" would be the cleanest.